### PR TITLE
Use logger instead of print as a way to avoid unicode issues

### DIFF
--- a/uploads/upload.py
+++ b/uploads/upload.py
@@ -331,7 +331,7 @@ class Upload(object):
             msg = 'Release title "{r}" does not match IMDb title "{i}".'
             logging.warning(msg.format(r=self.release.title, i=self.imdb.title))
             prompt = '\nIs this the correct IMDb link for the release? (Y/N)  {link}'
-            logging.info(prompt.format(link=self.imdb))
+            print(prompt.format(link=self.imdb.link))
             answer = raw_input()
             print()
             if answer.lower() == 'y':

--- a/uploads/upload.py
+++ b/uploads/upload.py
@@ -331,7 +331,7 @@ class Upload(object):
             msg = 'Release title "{r}" does not match IMDb title "{i}".'
             logging.warning(msg.format(r=self.release.title, i=self.imdb.title))
             prompt = '\nIs this the correct IMDb link for the release? (Y/N)  {link}'
-            print(prompt.format(link=self.imdb))
+            logging.info(prompt.format(link=self.imdb))
             answer = raw_input()
             print()
             if answer.lower() == 'y':


### PR DESCRIPTION
This avoids unicode issues on systems with broken locale, like Ubuntu 14.04, and systems where it can't be set.

The non ascii char in question is `É` from the title: `Quanto Vale Ou É Por Quilo?`

```
Traceback (most recent call last):
  File "/media/sda1/supergonkas/macguffin/auto_upload.py", line 104, in <module>
    dry_run=args.dry_run,
  File "/media/sda1/supergonkas/macguffin/uploads/upload.py", line 91, in start
    self.metadata_is_verified = self.verify_metadata()
  File "/media/sda1/supergonkas/macguffin/uploads/upload.py", line 334, in verify_metadata
    print(prompt.format(link=self.imdb))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xc9' in position 70: ordinal not in range(128)
```